### PR TITLE
Handle middleware errors in RPC calls

### DIFF
--- a/packages/backend/src/rpc/dispatcher.ts
+++ b/packages/backend/src/rpc/dispatcher.ts
@@ -62,13 +62,14 @@ export class RPCDispatcher extends BaseService {
     });
   }
 
-  private fail(e: Error) {
+  private fail = (e: Error) => {
     this.getSingleton(ServiceContextEvents)
       .disposeContext(this.context, e)
       .then(() => {
         if (typeof (e as any).code === 'number') {
           return this.jsonFail((e as any).code, e.message);
         } else if ((e as any).isJoi) {
+          // TODO: Joi specific handling, get rid of it
           console.error(`Validation failed for "${this.rpcPath}":`);
           (e as any).details.forEach((err: any) => console.error(` \-> ${err.message}`));
           return this.jsonFail(400, 'Technical error, the request was malformed.');
@@ -77,9 +78,9 @@ export class RPCDispatcher extends BaseService {
           return this.jsonFail(500, 'Something bad happened.');
         }
       });
-  }
+  };
 
-  private success(data: any, code: number = 200) {
+  private success = (data: any, code: number = 200) => {
     this.getSingleton(ServiceContextEvents)
       .disposeContext(this.context, null)
       .then(() => {
@@ -94,7 +95,7 @@ export class RPCDispatcher extends BaseService {
           });
         }
       });
-  }
+  };
 
   handleRequest() {
     let { req } = this;
@@ -116,10 +117,12 @@ export class RPCDispatcher extends BaseService {
     const promiseWrapper = Promise.resolve();
     return promiseWrapper
       .then(() => this.serviceMethod.call(this.serviceInstance, req.body.params) as Promise<any>)
-      .then(result => this.success(result), error => this.fail(error));
+      .then(this.success);
   }
 
   call = () => {
-    return this.getSingleton(RPCMiddlewareContainer).call(this);
+    return this.getSingleton(RPCMiddlewareContainer)
+      .call(this)
+      .catch(this.fail);
   };
 }

--- a/packages/backend/src/rpc/dispatcher.ts
+++ b/packages/backend/src/rpc/dispatcher.ts
@@ -115,14 +115,13 @@ export class RPCDispatcher extends BaseService {
 
     // in case the method is not a promise, we don't want the error to bubble-up
     const promiseWrapper = Promise.resolve();
-    return promiseWrapper
-      .then(() => this.serviceMethod.call(this.serviceInstance, req.body.params) as Promise<any>)
-      .then(this.success);
+    return promiseWrapper.then(() => this.serviceMethod.call(this.serviceInstance, req.body.params) as Promise<any>);
   }
 
   call = () => {
     return this.getSingleton(RPCMiddlewareContainer)
       .call(this)
+      .then(this.success)
       .catch(this.fail);
   };
 }

--- a/packages/backend/src/rpc/dispatcher.ts
+++ b/packages/backend/src/rpc/dispatcher.ts
@@ -121,7 +121,6 @@ export class RPCDispatcher extends BaseService {
   call = () => {
     return this.getSingleton(RPCMiddlewareContainer)
       .call(this)
-      .then(this.success)
-      .catch(this.fail);
+      .then(this.success, this.fail);
   };
 }

--- a/packages/backend/src/rpc/middleware.ts
+++ b/packages/backend/src/rpc/middleware.ts
@@ -9,11 +9,17 @@ export type RPCMiddleware = (dispatcher: RPCDispatcher, next: () => Promise<any>
  */
 export class RPCMiddlewareContainer extends AppSingleton {
   call = (dispatcher: RPCDispatcher) => {
-    return Promise.resolve(dispatcher.handleRequest());
+    return Promise.resolve().then(() => dispatcher.handleRequest());
   };
 
   addMiddleware(middleware: RPCMiddleware) {
     let oldCall = this.call;
-    this.call = (dispatcher: RPCDispatcher) => middleware.call(null, dispatcher, () => oldCall(dispatcher));
+    this.call = (dispatcher: RPCDispatcher) => {
+      try {
+        return middleware.call(null, dispatcher, () => oldCall(dispatcher));
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
   }
 }

--- a/packages/backend/src/rpc/middleware.ts
+++ b/packages/backend/src/rpc/middleware.ts
@@ -12,6 +12,12 @@ export class RPCMiddlewareContainer extends AppSingleton {
     return Promise.resolve().then(() => dispatcher.handleRequest());
   };
 
+  /**
+   * Adds new middleware to the RPC layer. Make sure that a middleware always returns a result.
+   * It might be a result that the middleware generates or modifies from the previos middleware,
+   * or it could be the result of the "next()" middleware. This way the result will be cascaded
+   * to the end of the middleware chain to achieve consistent success and error handling.
+   */
   addMiddleware(middleware: RPCMiddleware) {
     let oldCall = this.call;
     this.call = (dispatcher: RPCDispatcher) => {


### PR DESCRIPTION
Moved the RPC success and error handling logic to a higher level to achieve consistent and centralized success and error handling. Added promise rejection when error happens within middleware.