### PR TITLE
added a Router singleton on the backend

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -1,3 +1,4 @@
 export * from './request';
+export * from './router';
 export * from './rpc';
 export * from './db';

--- a/packages/backend/src/router/index.ts
+++ b/packages/backend/src/router/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Http router, based on Express.
+ */
+
+import { AppSingleton } from '@h4bff/core';
+import * as express from 'express';
+
+export class Router extends AppSingleton {
+  public router = express();
+}


### PR DESCRIPTION
The intent is to replace all `app.getSingleton(RequestContextProvider).router` calls with `app.getSingleton(Router).router`.

If we don't have a singleton like the one I created here, all apps will end up defining one and we don't want that I think.

@gphfour this goes against what you did, but lets talk on Monday.