### PR TITLE
Fixed unescaped characters in content-disposition header

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,10 +20,12 @@
   },
   "dependencies": {
     "@h4bff/core": "*",
+    "@types/content-disposition": "^0.5.2",
     "anydb-sql-2": "^3.1.1",
     "anydb-sql-2-migrations": "^3.0.2",
     "bluebird": "3.5.1",
     "body-parser": "1.18.3",
+    "content-disposition": "^0.5.2",
     "express": "4.16.4"
   },
   "devDependencies": {

--- a/packages/backend/src/rpc/response.ts
+++ b/packages/backend/src/rpc/response.ts
@@ -1,4 +1,5 @@
 import { Response } from 'express';
+import * as contentDisposition from 'content-disposition';
 
 export interface IRPCFileResult {
   fileName: string;
@@ -18,9 +19,8 @@ export class RPCFileResult implements CustomResponse, IRPCFileResult {
   constructor(public fileName: string, public buffer: Buffer) {}
 
   sendToHTTPResponse(res: Response, code: number) {
-    const escapedFilename = encodeURIComponent(this.fileName);
     res.status(code);
-    res.setHeader('Content-disposition', `attachment; filename*=UTF-8\'\'${escapedFilename}`);
+    res.setHeader('Content-disposition', contentDisposition(this.fileName));
     res.write(this.buffer, 'binary');
     res.end(null, 'binary');
     return res;

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,6 +51,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/content-disposition@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@types/content-disposition/-/content-disposition-0.5.2.tgz#18ccb0fd126808e498a820cb8149c0072a2b9066"
+  integrity sha1-GMyw/RJoCOSYqCDLgUnAByorkGY=
+
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
@@ -957,6 +962,13 @@ content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
   integrity sha1-DPaLud318r55YcOoUXjLhdunjLQ=
+
+content-disposition@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
+  integrity sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==
+  dependencies:
+    safe-buffer "5.1.2"
 
 content-type@~1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This solves a bug where files with names containing parenthesis couldn't be downloaded. 

## Dev notes
- To solve that, the value in the header is escaped using the "content-disposition" library, instead of "encodeURIComponent()". The first encodes wider range of characters, including parenthesis, and is compatible with how we decode the string on frontend.