### PR TITLE
Added ability to clear service and singleton overrides

### DIFF
--- a/packages/core/src/index.spec.ts
+++ b/packages/core/src/index.spec.ts
@@ -80,6 +80,33 @@ describe('Overrides', () => {
       return Promise.resolve();
     });
   });
+
+  it('#clearServiceOverrides should cause original services to instantiate', () => {
+    let app = new App();
+    app.overrideService(
+      UserProvider,
+      class MockUserProvider extends UserProvider {
+        id = 'mock-id';
+      },
+    );
+    app.clearServiceOverrides();
+    return app.withServiceContext(ctx => {
+      expect(ctx.getService(UserProvider)).toBeInstanceOf(UserProvider);
+      return Promise.resolve();
+    });
+  });
+
+  it('#clearSingletonOverrides should cause original singletons to instantiate', () => {
+    let app = new App();
+    app.overrideSingleton(
+      Database,
+      class MockDb extends Database {
+        id = 'mock-id';
+      },
+    );
+    app.clearSingletonOverrides();
+    expect(app.getSingleton(Database)).toBeInstanceOf(Database);
+  });
 });
 
 describe('App nesting', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,6 +95,13 @@ export class App {
   }
 
   /**
+   * Clears any defined singleton overrides.
+   */
+  clearSingletonOverrides() {
+    return this.singletonLocator.clearOverrides();
+  }
+
+  /**
    * Allows you to specify an alternative implementation for the
    * expected service. Each time someone tries to instantiate the
    * specified class / fn, the override is used instead. The type of
@@ -105,6 +112,13 @@ export class App {
     Klass2: ConstructorOrFactory<ServiceContext, PublicInterface<T>>,
   ) {
     return this.serviceLocator.override(Klass, Klass2);
+  }
+
+  /**
+   * Clears any defined service overrides.
+   */
+  clearServiceOverrides() {
+    return this.serviceLocator.clearOverrides();
   }
 
   /**
@@ -374,5 +388,9 @@ export class Locator<Context> {
 
   withNewContext(ctx: Context) {
     return new Locator(ctx, this.isClass, { overrides: this.overrides });
+  }
+
+  clearOverrides() {
+    this.overrides = new Map();
   }
 }


### PR DESCRIPTION
When testing or in scripts, you sometimes want to temporarily set an override which needs to be later removed. Without a clearing function, you need to instantiate a new app that doesn't have the overrides, or resort to hacks, like replacing / re-instantiating the Locator.

This PR adds two methods: `app.clearSingletonOverrides` and `ctx.clearServiceOverrides` which call `Locator#clearOverrides` in the corresponding Locator.