### PR TITLE
Unify request context handling

### DIFF
--- a/packages/backend/src/request/requestContextProvider.spec.ts
+++ b/packages/backend/src/request/requestContextProvider.spec.ts
@@ -4,35 +4,25 @@ import { Request, Response } from 'express';
 import { RequestInfo } from './requestInfo';
 
 describe('RequestContextProvider', () => {
-  it(`#getContext should create and return serviceContext for given request / response pair`, () => {
-    let app = new App();
-    let requestContextProvider = new RequestContextProvider(app);
-    let request = {} as Request;
-    let response = {} as Response;
-    let resultContext = requestContextProvider.getContext(request, response);
-    expect(resultContext).toBeDefined();
-  });
-
   it('#withRequestContext should prepare service context for given request / response pair', () => {
     let app = new App();
     let requestContextProvider = new RequestContextProvider(app);
     let request = {} as Request;
     let response = {} as Response;
-    return requestContextProvider.withRequestContext(request, response, sCtx => {
-      let requestInfo = sCtx.getService(RequestInfo);
-      expect(requestInfo.req).toEqual(request);
-      expect(requestInfo.res).toEqual(response);
+    let ctxDisposed = false;
+    app.getSingleton(ServiceContextEvents).onContextDisposed(() => {
+      ctxDisposed = true;
       return Promise.resolve();
     });
-  });
-
-  it('#onDispose should remove disposed service context from the context map', () => {
-    let app = new App();
-    let requestContextProvider = new RequestContextProvider(app);
-    let request = {} as Request;
-    let response = {} as Response;
-    let resultContext = requestContextProvider.getContext(request, response);
-    app.getSingleton(ServiceContextEvents).disposeContext(resultContext, null);
-    expect((requestContextProvider as any).contexts.has(request)).toBeFalsy();
+    return requestContextProvider
+      .withRequestContext(request, response, sCtx => {
+        let requestInfo = sCtx.getService(RequestInfo);
+        expect(requestInfo.req).toEqual(request);
+        expect(requestInfo.res).toEqual(response);
+        return Promise.resolve();
+      })
+      .then(() => {
+        expect(ctxDisposed).toBe(true);
+      });
   });
 });

--- a/packages/backend/src/request/requestContextProvider.ts
+++ b/packages/backend/src/request/requestContextProvider.ts
@@ -17,20 +17,6 @@ export class RequestContextProvider extends AppSingleton {
   }
 
   /**
-   * Creates a new service context and sets the req / res pair,
-   * unless there's already one, in which case it's returned instead.
-   */
-  public getContext(req: Express.Request, res: Express.Response) {
-    let result = this.contexts.get(req);
-    if (!result) {
-      result = this.app.createServiceContext();
-      result.getService(RequestInfo)._setRequestResponse(req, res);
-      this.contexts.set(req, result);
-    }
-    return result;
-  }
-
-  /**
    * Gets called on context disposal and makes sure that the service context
    * gets removed from the contexts map.
    */

--- a/packages/backend/src/rpc/serviceRegistry.ts
+++ b/packages/backend/src/rpc/serviceRegistry.ts
@@ -1,4 +1,3 @@
-import * as Promise from 'bluebird';
 import { Request, Response } from 'express';
 import { BaseService, AppSingleton, ServiceContext } from '@h4bff/core';
 import { RequestContextProvider } from '../request';
@@ -51,10 +50,9 @@ export class RPCServiceRegistry extends AppSingleton {
    * It binds the request and response to a service context and forwards the
    * request to the {@link RPCDispatcher}.
    */
-  routeHandler = (req: Request, res: Response): Promise<void | Response> => {
-    let dispatcher = this.getSingleton(RequestContextProvider)
-      .getContext(req, res)
-      .getService(RPCDispatcher);
-    return dispatcher.call();
+  routeHandler = (req: Request, res: Response) => {
+    return this.getSingleton(RequestContextProvider).withRequestContext(req, res, ctx =>
+      ctx.getService(RPCDispatcher).call(),
+    );
   };
 }


### PR DESCRIPTION
This should successfully avoid double-disposing; the RPC route handler now works like any route handler that wants a service context (via withRequestContext)