### PR TITLE
exposed hasSingleton() in App

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,7 +61,7 @@ export class App {
    * Checks if this or any of the parent apps has an instance of the
    * given singleton initialized.
    */
-  private hasSingleton<T>(Klass: ConstructorOrFactory<App, T>): boolean {
+  protected hasSingleton<T>(Klass: ConstructorOrFactory<App, T>): boolean {
     if (this.hasOwnSingleton(Klass)) {
       return true;
     } else {


### PR DESCRIPTION
in core: App, hasSingleton() has now protected instead of private access. 
The reason for this is because we want to be able to check from the plugins whether the config singletons have been loaded, before initializing the config.