### PR TITLE
make App.hasSingleton public

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,7 +61,7 @@ export class App {
    * Checks if this or any of the parent apps has an instance of the
    * given singleton initialized.
    */
-  protected hasSingleton<T>(Klass: ConstructorOrFactory<App, T>): boolean {
+  hasSingleton<T>(Klass: ConstructorOrFactory<App, T>): boolean {
     if (this.hasOwnSingleton(Klass)) {
       return true;
     } else {


### PR DESCRIPTION
In https://github.com/hfour/h4bff/pull/31, the hasSingleton method was mistakenly made protected instead of public - which prevented the plugins from using it.