### PR TITLE
Do not automatically revive transaction after disposal

### DIFF
--- a/packages/backend/src/db/transactionProvider.spec.ts
+++ b/packages/backend/src/db/transactionProvider.spec.ts
@@ -103,5 +103,21 @@ describe('TransactionProvider', () => {
           expect(transaction.rollbackAsync).toHaveBeenCalled();
         });
     });
+
+    it('should throw if transaction is used after service context ends', () => {
+      let { app } = prepare();
+
+      let tp: TransactionProvider = null!;
+      return app
+        .withServiceContext(sCtx => {
+          tp = sCtx.getService(TransactionProvider);
+          tp.tx;
+          return Promise.resolve();
+        })
+        .then(() => {
+          expect(() => tp.tx).toThrowError('Transaction is already closed');
+          expect(() => tp.conn).toThrowError('Transaction is already closed');
+        });
+    });
   });
 });


### PR DESCRIPTION
Once `onDispose` runs, the transaction should not automatically recreate the next time its requested. If this happens, any problematic code that continues after the request context ends will create a new transaction that will never get disposed (i.e. leak a connection)