### PR TITLE
fix(RPCDispatcher): gracefully handle non existant services and methods

### DIFF
--- a/packages/backend/src/rpc/dispatcher.spec.ts
+++ b/packages/backend/src/rpc/dispatcher.spec.ts
@@ -105,6 +105,7 @@ describe('RPCDispatcher', () => {
         let rpcDispatcher = sCtx.getService(RPCDispatcher);
         let requestInfo = sCtx.getService(RequestInfo);
 
+        expect(rpcDispatcher.serviceMethod).toEqual(undefined);
         return Promise.resolve(rpcDispatcher.handleRequest()).then(() => {
           expect(requestInfo.res.status).toHaveBeenCalledWith(404);
           expect(requestInfo.res.json).toHaveBeenCalledWith({

--- a/packages/backend/src/rpc/serviceRegistry.ts
+++ b/packages/backend/src/rpc/serviceRegistry.ts
@@ -6,7 +6,10 @@ import { RPCDispatcher } from '../rpc';
 /**
  * RPC service middleware.
  */
-export type RPCServiceMiddleware = (sCtx: ServiceContext, next: () => PromiseLike<void>) => PromiseLike<void>;
+export type RPCServiceMiddleware = (
+  sCtx: ServiceContext,
+  next: () => PromiseLike<void>,
+) => PromiseLike<void>;
 
 /**
  * Responsible for holding the RPC service mapping.
@@ -27,21 +30,9 @@ export class RPCServiceRegistry extends AppSingleton {
   }
 
   /**
-   * Checks if a given method exists on a RPC service given by its alias.
-   */
-  exists(alias: string, method: string) {
-    const ServiceClass = this.services[alias];
-    if (!ServiceClass) {
-      return false;
-    }
-    const serviceMethod = (ServiceClass.prototype as any)[method];
-    return typeof serviceMethod === 'function';
-  }
-
-  /**
    * Returns service for given alias.
    */
-  get(serviceAlias: string) {
+  get(serviceAlias: string): typeof BaseService | undefined {
     return this.services[serviceAlias];
   }
 


### PR DESCRIPTION
Removed the exists method since the existence check wasn't quite reliable; moved it to the dispatcher itself.

This PR allows middleware to query serviceMethod and serviceInstance even when the specified service name and method are invalid. The middleware will now get a possibly `undefined` result which they need to handle accordingly.