### PR TITLE
Patch core to 1.0.7

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h4bff/core",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "H4BFF, the core: dependency injection, overrides, apps singletons and services.",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
Increases the version of the core package to 1.0.7.

Cherry-picked an unmerged commit from the branch emil/expose-has-singleton-again ( ab5e21942a0d5b2ab2b2dc19e3b2f63056194b3f ), which was then left because it was pushed to the branch AFTER the branch was merged to master.