### PR TITLE
fix(frontend): router redirects

### DIFF
--- a/packages/frontend/src/app-context.ts
+++ b/packages/frontend/src/app-context.ts
@@ -15,3 +15,6 @@ import { App } from '@h4bff/core';
  * @public
  */
 export const AppContext = React.createContext({} as { app: App });
+export interface AppContextProps {
+  app: App;
+}

--- a/packages/frontend/src/router/routeProvider.ts
+++ b/packages/frontend/src/router/routeProvider.ts
@@ -12,9 +12,11 @@ export class RouteProvider extends AppSingleton {
   constructor(app: App) {
     super(app);
 
-    this.browserHistory = createBrowserHistory();
+    this.browserHistory = this.getSingleton(HistoryProvider);
     this.location = this.browserHistory.location;
 
     this.browserHistory.listen(location => runInAction(() => (this.location = location)));
   }
 }
+
+export let HistoryProvider = () => createBrowserHistory();

--- a/packages/frontend/src/router/router.spec.tsx
+++ b/packages/frontend/src/router/router.spec.tsx
@@ -12,27 +12,25 @@ const carsPage = jest.fn(_p1 => <div>Sample page</div>);
 describe('router', () => {
   let app: App;
   let router: Router;
+  let renderer: TestRenderer.ReactTestRenderer;
 
-  const withRoutingInstance = (f: (visit: (url: string) => void) => void) => {
-    TestRenderer.create(<router.RenderInstance />);
-
-    function visit(path: string) {
+  function visitUrl(path: string) {
+    TestRenderer.act(() => {
       const routeProvider = app.getSingleton(RouteProvider);
-      // const parsedUrl = url.parse(path);
       routeProvider.browserHistory.push(path);
-    }
-    TestRenderer.act(() => f(visit));
-  };
-
-  const visitUrl = (path: string) => {
-    return withRoutingInstance(visit => visit(path));
-  };
+    });
+  }
 
   beforeEach(() => {
     jest.clearAllMocks();
     app = new App();
     app.overrideSingleton(HistoryProvider, () => createMemoryHistory());
     router = app.getSingleton(Router);
+    renderer = TestRenderer.create(<router.RenderInstance />);
+  });
+
+  afterEach(() => {
+    renderer.unmount();
   });
 
   describe('matching routes', () => {
@@ -172,18 +170,16 @@ describe('router', () => {
       router.addRoute('/example', potatoesPage);
       router.addRedirect({ from: '/lol', to: '/route' });
 
-      withRoutingInstance(visitUrl => {
-        let routeProvider = app.getSingleton(RouteProvider);
+      let routeProvider = app.getSingleton(RouteProvider);
 
-        visitUrl('/example');
-        expect(routeProvider.location.pathname).toEqual('/example');
+      visitUrl('/example');
+      expect(routeProvider.location.pathname).toEqual('/example');
 
-        visitUrl('/lol');
-        expect(routeProvider.location.pathname).toEqual('/route');
+      visitUrl('/lol');
+      expect(routeProvider.location.pathname).toEqual('/route');
 
-        routeProvider.browserHistory.goBack();
-        expect(routeProvider.location.pathname).toEqual('/example');
-      });
+      routeProvider.browserHistory.goBack();
+      expect(routeProvider.location.pathname).toEqual('/example');
     });
   });
 

--- a/packages/frontend/src/router/router.tsx
+++ b/packages/frontend/src/router/router.tsx
@@ -64,7 +64,7 @@ class MobxRouter {
       matchPath(location.pathname, redirect.from),
     );
     if (matchedRedirect) {
-      routeProvider.browserHistory.push(matchedRedirect.to);
+      routeProvider.browserHistory.replace(matchedRedirect.to);
     } else {
       const matchedRoute = this.routes.find(route => route.match(location) !== null);
       if (matchedRoute) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,10 +522,18 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.7.13":
+"@types/react@*":
   version "16.8.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.14.tgz#b561bfabeb8f60d12e6d4766367e7a9ae927aa18"
   integrity sha512-26tFVJ1omGmzIdFTFmnC5zhz1GTaqCjxgUxV4KzWvsybF42P7/j4RBn6UeO3KbHPXqKWZszMXMoI65xIWm954A==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/react@^16.7.13":
+  version "16.8.24"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.24.tgz#8d1ea1fcbfa214220da3d3c04e506f1077b0deac"
+  integrity sha512-VpFHUoD37YNY2+lr/+c7qL/tZsIU/bKuskUF3tmGUArbxIcQdb5j3zvo4cuuzu2A6UaVmVn7sJ4PgWYNFEBGzg==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -522,18 +522,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
+"@types/react@*", "@types/react@^16.7.13":
   version "16.8.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.14.tgz#b561bfabeb8f60d12e6d4766367e7a9ae927aa18"
   integrity sha512-26tFVJ1omGmzIdFTFmnC5zhz1GTaqCjxgUxV4KzWvsybF42P7/j4RBn6UeO3KbHPXqKWZszMXMoI65xIWm954A==
-  dependencies:
-    "@types/prop-types" "*"
-    csstype "^2.2.0"
-
-"@types/react@^16.7.13":
-  version "16.8.24"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.24.tgz#8d1ea1fcbfa214220da3d3c04e506f1077b0deac"
-  integrity sha512-VpFHUoD37YNY2+lr/+c7qL/tZsIU/bKuskUF3tmGUArbxIcQdb5j3zvo4cuuzu2A6UaVmVn7sJ4PgWYNFEBGzg==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
This fixes router redirects breaking the back button. Browser history is now also set to memory history in testing mode, which enables full testing of the router by driving the history instead of the route provider.

The router was modified to use computed values instead of reactions to determine the components, and use autorun only for side effects that dispatch changes to external modules (i.e. history)