### PR TITLE
feat(frontend): routeParams computed preventing reload when adding routes

### DIFF
--- a/packages/frontend/src/router/router.spec.tsx
+++ b/packages/frontend/src/router/router.spec.tsx
@@ -131,6 +131,42 @@ describe('router', () => {
       expect(params[0].queryParams.first).toEqual('1');
       expect(params[0].queryParams.second).toEqual('2');
     });
+
+    it('should not refresh when route params change', () => {
+      router.addRoute('/example/:paramone/:paramtwo', potatoesPage);
+
+      visitUrl('/example/p1/p2');
+      expect(potatoesPage.mock.calls[0][0].paramone).toEqual('p1');
+      expect(potatoesPage.mock.calls[0][0].paramtwo).toEqual('p2');
+
+      visitUrl('/example/p3/p4');
+      expect(router.routeParams.paramone).toEqual('p3');
+      expect(router.routeParams.paramtwo).toEqual('p4');
+
+      expect(potatoesPage).toBeCalledTimes(1);
+    });
+
+    it('should not refresh when query params change', () => {
+      router.addRoute('/example/:paramone', potatoesPage);
+
+      visitUrl('/example/p1?first=1&second=2');
+      expect(router.routeParams.paramone).toEqual('p1');
+      expect(router.routeParams.queryParams.first).toEqual('1');
+      expect(router.routeParams.queryParams.second).toEqual('2');
+
+      visitUrl('/example/p1?first=1&second=3');
+      expect(router.routeParams.paramone).toEqual('p1');
+      expect(router.routeParams.queryParams.first).toEqual('1');
+      expect(router.routeParams.queryParams.second).toEqual('3');
+
+      visitUrl('/example/p1?first=1');
+      expect(router.routeParams.paramone).toEqual('p1');
+      expect(router.routeParams.queryParams.first).toEqual('1');
+      expect(router.routeParams.queryParams.second).not.toEqual('2');
+      expect(router.routeParams.queryParams.second).not.toEqual('3');
+
+      expect(potatoesPage).toBeCalledTimes(1);
+    });
   });
 
   describe('handling redirects', () => {
@@ -178,7 +214,7 @@ describe('router', () => {
       expect(routeProvider.location.pathname).toEqual('/redirected');
     });
 
-    it('should NOT redirect from url if route param doesnt match', () => {
+    it('should not redirect from url if route param doesnt match', () => {
       router.addRedirect({ from: '/example/:param', to: '/redirected' });
       visitUrl('/example');
 

--- a/packages/frontend/src/router/router.spec.tsx
+++ b/packages/frontend/src/router/router.spec.tsx
@@ -132,7 +132,7 @@ describe('router', () => {
       expect(params[0].queryParams.second).toEqual('2');
     });
 
-    it('should not refresh when route params change', () => {
+    it('should refresh when route params change', () => {
       router.addRoute('/example/:paramone/:paramtwo', potatoesPage);
 
       visitUrl('/example/p1/p2');
@@ -143,10 +143,10 @@ describe('router', () => {
       expect(router.routeParams.paramone).toEqual('p3');
       expect(router.routeParams.paramtwo).toEqual('p4');
 
-      expect(potatoesPage).toBeCalledTimes(1);
+      expect(potatoesPage).toBeCalledTimes(2);
     });
 
-    it('should not refresh when query params change', () => {
+    it('should refresh when query params change', () => {
       router.addRoute('/example/:paramone', potatoesPage);
 
       visitUrl('/example/p1?first=1&second=2');
@@ -165,7 +165,7 @@ describe('router', () => {
       expect(router.routeParams.queryParams.second).not.toEqual('2');
       expect(router.routeParams.queryParams.second).not.toEqual('3');
 
-      expect(potatoesPage).toBeCalledTimes(1);
+      expect(potatoesPage).toBeCalledTimes(3);
     });
   });
 

--- a/packages/frontend/src/router/router.spec.tsx
+++ b/packages/frontend/src/router/router.spec.tsx
@@ -60,6 +60,14 @@ describe('router', () => {
       expect(carsPage).toBeCalled();
     });
 
+    it('should not reload current route when adding routes', () => {
+      router.addRoute('/potatoes', potatoesPage);
+      visitUrl('/potatoes');
+      router.addRoute('/cars', carsPage);
+      expect(potatoesPage).toBeCalledTimes(1);
+      expect(carsPage).not.toBeCalled();
+    });
+
     it('should match only the lastly added route if they have the same path', () => {
       router.addRoute('/example', potatoesPage);
       router.addRoute('/example', carsPage);

--- a/packages/frontend/src/router/router.tsx
+++ b/packages/frontend/src/router/router.tsx
@@ -39,6 +39,7 @@ export interface Redirect {
 class MobxRouter {
   @observable private routes: Array<Route<any>> = [];
   @observable private redirects: Array<Redirect> = [];
+  routeParams: RouteParameters<any> = null;
 
   constructor(private app: App) {
     autorun(() => {
@@ -59,8 +60,10 @@ class MobxRouter {
   @computed get matchedRoute() {
     if (this.matchedRedirect) return null;
     for (let route of this.routes) {
-      let params = route.match(this.location);
-      if (params) return { params, component: route.component };
+      this.routeParams = route.match(this.location);
+      if (this.routeParams) {
+        return route.component;
+      }
     }
     return null;
   }
@@ -98,7 +101,7 @@ class MobxRouter {
   }
 
   RenderInstance = observer(() => {
-    return this.matchedRoute && this.matchedRoute.component(this.matchedRoute.params);
+    return this.matchedRoute && this.matchedRoute(this.routeParams);
   });
 }
 
@@ -116,6 +119,10 @@ export class Router extends AppSingleton {
   addRedirect = (newRedirect: Redirect) => {
     return this.router.addRedirect(newRedirect);
   };
+
+  get routeParams() {
+    return this.router.routeParams;
+  }
 
   RenderInstance = observer(() => {
     const routeProvider = this.getSingleton(RouteProvider);


### PR DESCRIPTION
Solves the case when routes are added dynamically (async) on a page and the components got reloaded. Reason for this is `matchedRoute` returns new params causing observer `RenderInstance` to trigger.
Solution is to return the component while keeping the existing parameters.