### PR TITLE
feat (frontend): add "exact" and "strict" props to <Link>

### DIFF
--- a/packages/frontend/src/router/link.spec.tsx
+++ b/packages/frontend/src/router/link.spec.tsx
@@ -1,0 +1,126 @@
+import { App } from '@h4bff/core';
+import * as React from 'react';
+import { createMemoryHistory } from 'history';
+import * as TestRenderer from 'react-test-renderer';
+import { RouteProvider, HistoryProvider } from './routeProvider';
+import { Router } from './router';
+import { Link } from './link';
+
+describe('link', () => {
+  let app: App;
+  let router: Router;
+  let renderer: TestRenderer.ReactTestRenderer;
+
+  /**
+   * Creates a <Link> component with the text "link" so it can be easily found by the test renderer.
+   * Has 2 optional parameters, exact and strict, that are directly sent as props to the Link component.
+   */
+  function createLink(to: string, exact?: boolean, strict?: boolean) {
+    return jest.fn(_p1 => (
+      <Link activeClassName="active" exact={exact} strict={strict} to={to}>
+        link
+      </Link>
+    ));
+  }
+
+  /**
+   * Helper function that checks whether the link present in the renderer has the "active" classname.
+   */
+  function isLinkActive() {
+    const rendererInstance = renderer.root;
+
+    const link = rendererInstance.find(
+      element => element.children && element.children[0] == 'link',
+    );
+
+    return link.props.className == 'active';
+  }
+
+  function visitUrl(path: string) {
+    TestRenderer.act(() => {
+      const routeProvider = app.getSingleton(RouteProvider);
+      routeProvider.browserHistory.push(path);
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = new App();
+    app.overrideSingleton(HistoryProvider, () => createMemoryHistory());
+    router = app.getSingleton(Router);
+
+    TestRenderer.act(() => {
+      renderer = TestRenderer.create(<router.RenderInstance />);
+    });
+  });
+
+  afterEach(() => {
+    renderer.unmount();
+  });
+
+  describe('link being active', () => {
+    describe('with default params', () => {
+      it('should be active when pointing to the current location', () => {
+        //given
+        const link = createLink('/example/lala');
+        router.addRoute('/example/lala', link);
+
+        //when
+        visitUrl('/example/lala');
+
+        //then
+        expect(isLinkActive()).toEqual(true);
+      });
+
+      it('should be active when pointing to a partial match of the current location', () => {
+        //given
+        const link = createLink('/example');
+        router.addRoute('/example/lala', link);
+
+        //when
+        visitUrl('/example/lala');
+
+        //then
+        expect(isLinkActive()).toEqual(true);
+      });
+
+      it('should NOT be active when pointing to route longer than the current location', () => {
+        //given
+        const link = createLink('/example/lala');
+        router.addRoute('/example', link);
+
+        //when
+        visitUrl('/example');
+
+        //then
+        expect(isLinkActive()).toEqual(false);
+      });
+    });
+
+    describe('with "exact" param', () => {
+      it('should be active when pointing to the current location', () => {
+        //given
+        const link = createLink('/example/lala', true);
+        router.addRoute('/example/lala', link);
+
+        //when
+        visitUrl('/example/lala');
+
+        //then
+        expect(isLinkActive()).toEqual(true);
+      });
+
+      it('should NOT be active when pointing to a partial match of the current location', () => {
+        //given
+        const link = createLink('/example', true);
+        router.addRoute('/example/lala', link);
+
+        //when
+        visitUrl('/example/lala');
+
+        //then
+        expect(isLinkActive()).toEqual(false);
+      });
+    });
+  });
+});

--- a/packages/frontend/src/router/link.tsx
+++ b/packages/frontend/src/router/link.tsx
@@ -58,7 +58,7 @@ export class Link extends React.Component<LinkProps, {}> {
           const { innerRef, replace, to, activeClassName, exact, strict, ...rest } = this.props; // eslint-disable-line no-unused-vars
           const path = typeof to === 'string' ? to : to.pathname;
           const escapedPath = path && path.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1');
-          const isActive = matchPath(currentLocation, escapedPath, exact, strict);
+          const isActive = matchPath(currentLocation, escapedPath, { exact, strict });
 
           let className;
           if (isActive) {

--- a/packages/frontend/src/router/link.tsx
+++ b/packages/frontend/src/router/link.tsx
@@ -55,10 +55,10 @@ export class Link extends React.Component<LinkProps, {}> {
           }
 
           const currentLocation = context.location;
-          const { innerRef, replace, to, activeClassName, ...rest } = this.props; // eslint-disable-line no-unused-vars
+          const { innerRef, replace, to, activeClassName, exact, strict, ...rest } = this.props; // eslint-disable-line no-unused-vars
           const path = typeof to === 'string' ? to : to.pathname;
           const escapedPath = path && path.replace(/([.+*?=^!:${}()[\]|/\\])/g, '\\$1');
-          const isActive = escapedPath ? matchPath(currentLocation, escapedPath) : false;
+          const isActive = matchPath(currentLocation, escapedPath, exact, strict);
 
           let className;
           if (isActive) {

--- a/packages/frontend/src/router/router.tsx
+++ b/packages/frontend/src/router/router.tsx
@@ -54,7 +54,7 @@ class MobxRouter {
   }
 
   @computed get matchedRedirect() {
-    return this.redirects.find(redirect => matchPath(this.location.pathname, redirect.from));
+    return this.redirects.find(redirect => matchPath(this.location.pathname, redirect.from, true));
   }
 
   @computed get routeParams() {

--- a/packages/frontend/src/router/router.tsx
+++ b/packages/frontend/src/router/router.tsx
@@ -54,7 +54,9 @@ class MobxRouter {
   }
 
   @computed get matchedRedirect() {
-    return this.redirects.find(redirect => matchPath(this.location.pathname, redirect.from, true));
+    return this.redirects.find(redirect =>
+      matchPath(this.location.pathname, redirect.from, { exact: true }),
+    );
   }
 
   @computed get routeParams() {

--- a/packages/frontend/src/router/routerUtils.ts
+++ b/packages/frontend/src/router/routerUtils.ts
@@ -3,13 +3,7 @@ import * as pathToRegexp from 'path-to-regexp';
 export function matchPath(
   currentPath: string,
   regexPathToMatch: string | undefined,
-  {
-    exact = false,
-    strict = false,
-  }: {
-    exact?: boolean;
-    strict?: boolean;
-  },
+  { exact = false, strict = false },
 ) {
   if (!regexPathToMatch) {
     return null;

--- a/packages/frontend/src/router/routerUtils.ts
+++ b/packages/frontend/src/router/routerUtils.ts
@@ -3,8 +3,13 @@ import * as pathToRegexp from 'path-to-regexp';
 export function matchPath(
   currentPath: string,
   regexPathToMatch: string | undefined,
-  exact: boolean = false,
-  strict: boolean = false,
+  {
+    exact = false,
+    strict = false,
+  }: {
+    exact?: boolean;
+    strict?: boolean;
+  },
 ) {
   if (!regexPathToMatch) {
     return null;

--- a/packages/frontend/src/router/routerUtils.ts
+++ b/packages/frontend/src/router/routerUtils.ts
@@ -1,7 +1,21 @@
 import * as pathToRegexp from 'path-to-regexp';
 
-export function matchPath(currentPath: string, regexPathToMatch: string) {
-  const regexp = pathToRegexp(regexPathToMatch);
+export function matchPath(
+  currentPath: string,
+  regexPathToMatch: string | undefined,
+  exact: boolean = false,
+  strict: boolean = false,
+) {
+  if (!regexPathToMatch) {
+    return null;
+  }
+  const keys: pathToRegexp.Key[] = [];
+  const options = {
+    end: exact,
+    strict,
+    sensitive: false,
+  };
+  const regexp = pathToRegexp(regexPathToMatch, keys, options);
   return regexp.exec(currentPath) != null;
 }
 


### PR DESCRIPTION
`<Link>` now handles the previously ignored "exact" and "strict" props. 
Both props are used for determining when the activeClassname prop will be added to the Link component classnames. Examples can be found in https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/Route.md.

The default value of both properties is "false".

<h2>Breaking changes</h2>

**Link:** By default the `Link` component sets the `exact` option to `false`, previously it behaved as it's set to true. `strict` is added as an option to `Link` as well.
