### PR TITLE
Fix various minor papercuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@microsoft/api-extractor": "^7.1.0",
     "docsify-tools": "^1.0.19",
     "gh-pages": "^2.0.1",
-    "path-to-regexp": "^3.0.0",
     "prettier": "^1.15.3",
     "typescript": "^3.4.5",
     "wsrun": "^5.0.0"

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,8 @@
     "bluebird": "3.5.1",
     "body-parser": "1.18.3",
     "content-disposition": "^0.5.2",
-    "express": "4.16.4"
+    "express": "4.16.4",
+    "tslib": "^1.7.0"
   },
   "devDependencies": {
     "@types/bluebird": "3.5.27",

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -2,9 +2,10 @@
   "extends": "../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
-    "outDir": "./build",
+    "outDir": "build",
+    "tsBuildInfoFile": "build/tsconfig.tsbuildinfo",
     "declaration": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationMap": true
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,9 @@
   "description": "H4BFF, the core: dependency injection, overrides, apps singletons and services.",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "dependencies": {
+    "tslib": "^1.7.0"
+  },
   "files": [
     "build/**/*",
     "src/**/*"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,9 +2,10 @@
   "extends": "../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
-    "outDir": "./build",
+    "outDir": "build",
+    "tsBuildInfoFile": "build/tsconfig.tsbuildinfo",
     "declaration": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationMap": true
   }
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -29,7 +29,8 @@
     "path-to-regexp": "^3.0.0",
     "query-string": "^6.2.0",
     "react": "^16.7.7",
-    "react-dom": "^16.6.3"
+    "react-dom": "^16.6.3",
+    "tslib": "^1.7.0"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.9",

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -2,9 +2,10 @@
   "extends": "../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
-    "outDir": "./build",
+    "outDir": "build",
+    "tsBuildInfoFile": "build/tsconfig.tsbuildinfo",
     "declaration": true,
-    "rootDir": "./src",
+    "rootDir": "src",
     "declarationMap": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "importHelpers": true,
     "strict": true,
     "preserveWatchOutput": true,
     "incremental": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,9 +4110,9 @@ set-value@^0.4.3:
     to-object-path "^0.3.0"
 
 set-value@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
-  integrity sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.1.tgz#a18d40530e6f07de4228c7defe4227af8cad005b"
+  integrity sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
   dependencies:
     extend-shallow "^2.0.1"
     is-extendable "^0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4576,6 +4576,11 @@ ts-jest@^24.0.2:
     semver "^5.5"
     yargs-parser "10.x"
 
+tslib@^1.7.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"


### PR DESCRIPTION
This PR fixes several small issues (papercuts):
- `importHelpers` is added to tsconfig. This adds additional library as a dependency but it's deduped by the end user of the library. This simplifies and removes duplicate code (decorator shims etc). The version was set to 1.7.0 because it requires a minimum of TS 2.3.2 which seems like an old enough target.
- A dependency (`path-to-regexp`) was declared in the main `package.json` which was used only in `h4bff/frontend` but was already declared there.
- The `tsbuildinfo` file was outside the build folder. This can cause issues because the file is not cleaned by the 'yarn clean' command.
- Fix `set-value` package to a non-vulnerable version. This is of no consequence to the end user, so it's just to shut up the Github alerts.