### PR TITLE
fix: transaction disposal and service context creation

### DIFF
--- a/packages/backend/src/request/request-context-provider.spec.ts
+++ b/packages/backend/src/request/request-context-provider.spec.ts
@@ -33,16 +33,13 @@ describe('RequestContextProvider', () => {
     let requestContextProvider = new RequestContextProvider(app);
     return requestContextProvider
       .withRequestContext(request, response, _sctx => {
-        return Promise.resolve(
-          expect(() => {
-            return requestContextProvider.withRequestContext(request, response, () =>
-              Promise.resolve(),
-            );
-          }).toThrow('Attempted to create a request context within the request context'),
-        );
+        expect(() => {
+          requestContextProvider.withRequestContext(request, response, () => Promise.resolve());
+        }).toThrow('Attempted to create a request context within the request context');
+        return Promise.resolve();
       })
       .then(() => {
-        return expect(() => {
+        expect(() => {
           requestContextProvider.withRequestContext(request, response, () => Promise.resolve());
         }).not.toThrow();
       });

--- a/packages/backend/src/request/request-context-provider.spec.ts
+++ b/packages/backend/src/request/request-context-provider.spec.ts
@@ -31,15 +31,18 @@ describe('RequestContextProvider', () => {
 
     let app = new App();
     let requestContextProvider = new RequestContextProvider(app);
-    requestContextProvider
+    return requestContextProvider
       .withRequestContext(request, response, _sctx => {
-        expect(() => {
-          requestContextProvider.withRequestContext(request, response, () => Promise.resolve());
-        }).toThrow();
-        return Promise.resolve();
+        return Promise.resolve(
+          expect(() => {
+            return requestContextProvider.withRequestContext(request, response, () =>
+              Promise.resolve(),
+            );
+          }).toThrow('Attempted to create a request context within the request context'),
+        );
       })
       .then(() => {
-        expect(() => {
+        return expect(() => {
           requestContextProvider.withRequestContext(request, response, () => Promise.resolve());
         }).not.toThrow();
       });

--- a/packages/backend/src/request/request-context-provider.ts
+++ b/packages/backend/src/request/request-context-provider.ts
@@ -54,6 +54,7 @@ export class RequestContextProvider extends AppSingleton {
     }
     return this.app.withServiceContext(ctx => {
       ctx.getService(RequestInfo)._setRequestResponse(req, res);
+      this.contexts.set(req, ctx);
       return f(ctx);
     });
   }

--- a/packages/backend/src/rpc/dispatcher.spec.ts
+++ b/packages/backend/src/rpc/dispatcher.spec.ts
@@ -164,10 +164,6 @@ describe('RPCDispatcher', () => {
             });
           });
         })
-        .then(
-          () => {},
-          () => {},
-        )
         .then(() => {
           expect(app.getSingleton(ServiceContextEvents).disposeContext).toHaveBeenCalled();
         });
@@ -210,10 +206,6 @@ describe('RPCDispatcher', () => {
             expect(mockData.sendToHTTPResponse).toHaveBeenCalledWith(requestInfo.res, 200);
           });
         })
-        .then(
-          () => {},
-          () => {},
-        )
         .then(() => {
           expect(app.getSingleton(ServiceContextEvents).disposeContext).toHaveBeenCalled();
         });
@@ -249,24 +241,24 @@ describe('RPCDispatcher', () => {
           let rpcDispatcher = sCtx.getService(RPCDispatcher);
           let requestInfo = sCtx.getService(RequestInfo);
 
-          return rpcDispatcher.call().then(() => {
-            expect(requestInfo.res.status).toHaveBeenCalledWith(403);
-            expect(requestInfo.res.json).toHaveBeenCalledWith({
-              code: 403,
-              result: null,
-              error: {
+          return rpcDispatcher.call().then(
+            () => {},
+            err => {
+              expect(err).toEqual(expect.objectContaining({ code: 403, message: 'error' }));
+              expect(requestInfo.res.status).toHaveBeenCalledWith(403);
+              expect(requestInfo.res.json).toHaveBeenCalledWith({
                 code: 403,
-                message: 'error',
-              },
-              version: 2,
-              backendError: true,
-            });
-          });
+                result: null,
+                error: {
+                  code: 403,
+                  message: 'error',
+                },
+                version: 2,
+                backendError: true,
+              });
+            },
+          );
         })
-        .then(
-          () => {},
-          () => {},
-        )
         .then(() => {
           expect(app.getSingleton(ServiceContextEvents).disposeContext).toHaveBeenCalled();
         });
@@ -302,24 +294,24 @@ describe('RPCDispatcher', () => {
           let rpcDispatcher = sCtx.getService(RPCDispatcher);
           let requestInfo = sCtx.getService(RequestInfo);
 
-          return rpcDispatcher.call().then(() => {
-            expect(requestInfo.res.status).toHaveBeenCalledWith(400);
-            expect(requestInfo.res.json).toHaveBeenCalledWith({
-              code: 400,
-              result: null,
-              error: {
+          return rpcDispatcher.call().then(
+            () => {},
+            err => {
+              expect(err).toEqual(expect.objectContaining({ isJoi: true, details: [] }));
+              expect(requestInfo.res.status).toHaveBeenCalledWith(400);
+              expect(requestInfo.res.json).toHaveBeenCalledWith({
                 code: 400,
-                message: 'Technical error, the request was malformed.',
-              },
-              version: 2,
-              backendError: true,
-            });
-          });
+                result: null,
+                error: {
+                  code: 400,
+                  message: 'Technical error, the request was malformed.',
+                },
+                version: 2,
+                backendError: true,
+              });
+            },
+          );
         })
-        .then(
-          () => {},
-          () => {},
-        )
         .then(() => {
           expect(app.getSingleton(ServiceContextEvents).disposeContext).toHaveBeenCalled();
         });
@@ -354,24 +346,24 @@ describe('RPCDispatcher', () => {
           let rpcDispatcher = sCtx.getService(RPCDispatcher);
           let requestInfo = sCtx.getService(RequestInfo);
 
-          return rpcDispatcher.call().then(() => {
-            expect(requestInfo.res.status).toHaveBeenCalledWith(500);
-            expect(requestInfo.res.json).toHaveBeenCalledWith({
-              code: 500,
-              result: null,
-              error: {
+          return rpcDispatcher.call().then(
+            () => {},
+            err => {
+              expect(err).toEqual('error');
+              expect(requestInfo.res.status).toHaveBeenCalledWith(500);
+              expect(requestInfo.res.json).toHaveBeenCalledWith({
                 code: 500,
-                message: 'An unexpected error occurred. Please try again.',
-              },
-              version: 2,
-              backendError: true,
-            });
-          });
+                result: null,
+                error: {
+                  code: 500,
+                  message: 'An unexpected error occurred. Please try again.',
+                },
+                version: 2,
+                backendError: true,
+              });
+            },
+          );
         })
-        .then(
-          () => {},
-          () => {},
-        )
         .then(() => {
           expect(app.getSingleton(ServiceContextEvents).disposeContext).toHaveBeenCalled();
         });

--- a/packages/backend/src/rpc/dispatcher.ts
+++ b/packages/backend/src/rpc/dispatcher.ts
@@ -125,6 +125,9 @@ export class RPCDispatcher extends BaseService {
   call = () => {
     return this.getSingleton(RPCMiddlewareContainer)
       .call(this)
-      .then(this.success, this.fail);
+      .then(this.success, err => {
+        this.fail(err);
+        throw err;
+      });
   };
 }


### PR DESCRIPTION
Fixes transaction disposal and service context creation.
- Ensure no nested contexts in `RequestContextProvider.withRequestContext`
  - Fixed test to ensure correct error is thrown
- Ensure `RPCDispatcher` to re-throw errors
  - Fixed test to correctly catch errors

