### PR TITLE
minor: Attach interceptors when using Locator.withNewContext

### DIFF
--- a/packages/core/src/locator.spec.ts
+++ b/packages/core/src/locator.spec.ts
@@ -1,0 +1,81 @@
+import { App } from '.';
+import { Locator, Interceptor } from './locator';
+
+describe('Locator', () => {
+  it('override a function using the override option in constructor', () => {
+    let original = () => 'original';
+    let override = () => 'override';
+
+    const overrides = new Map();
+    overrides.set(original, override);
+    let app = new App();
+    let loc = new Locator(app, s => '__appSingleton' in s, { overrides });
+
+    expect(loc.get(original)).toBe('override');
+  });
+
+  it('override a function using the override method', () => {
+    let original = () => 'original';
+    let override = () => 'override';
+
+    let app = new App();
+    let loc = new Locator(app, s => '__appSingleton' in s, {});
+    loc.override(original, override);
+
+    expect(loc.get(original)).toBe('override');
+  });
+
+  it('addInterceptor should add an interceptor', () => {
+    const mock = jest.fn();
+    const testInterceptor = <Context>(): Interceptor<Context> => {
+      return instantiator => f => {
+        mock();
+        return instantiator(f);
+      };
+    };
+
+    let app = new App();
+    let loc = new Locator(app, s => '__appSingleton' in s);
+    loc.addInterceptor(testInterceptor());
+    loc.get(() => {});
+
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+
+  it('withNewContext should not share the overrides', () => {
+    let original = () => 'original';
+    let fstOverride = () => 'override 1';
+    let sndOverride = () => 'override 2';
+
+    let fstApp = new App();
+    let loc = new Locator(fstApp, s => '__appSingleton' in s);
+    loc.override(original, fstOverride);
+
+    const sndApp = new App();
+    const clonedLoc = loc.withNewContext(sndApp);
+    clonedLoc.override(original, sndOverride);
+
+    expect(loc.get(original)).toBe('override 1');
+    expect(clonedLoc.get(original)).toBe('override 2');
+  });
+
+  it('withNewContext should add the interceptors', () => {
+    const mock = jest.fn();
+    const testInterceptor = <Context>(): Interceptor<Context> => {
+      return instantiator => f => {
+        mock();
+        return instantiator(f);
+      };
+    };
+
+    let fstApp = new App();
+    let loc = new Locator(fstApp, s => '__appSingleton' in s);
+    loc.addInterceptor(testInterceptor());
+
+    const sndApp = new App();
+    const clonedLoc = loc.withNewContext(sndApp);
+    clonedLoc.get(() => {});
+
+    expect(mock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/locator.spec.ts
+++ b/packages/core/src/locator.spec.ts
@@ -1,25 +1,25 @@
 import { App } from '.';
-import { Locator, Interceptor } from './locator';
+import { Locator, OverrideInterceptor } from './locator';
 
 describe('Locator', () => {
-  it('override a function using the override option in constructor', () => {
-    let original = () => 'original';
-    let override = () => 'override';
-
-    const overrides = new Map();
-    overrides.set(original, override);
-    let app = new App();
-    let loc = new Locator(app, s => '__appSingleton' in s, { overrides });
-
-    expect(loc.get(original)).toBe('override');
-  });
+  class TestInterceptor<C> {
+    constructor(private l: Locator<C>, private mockF: jest.Mock<any, any>) {}
+    get = (i: any) => (f: any) => {
+      this.mockF();
+      return i(f);
+    };
+    inherit() {
+      return new TestInterceptor(this.l, this.mockF);
+    }
+  }
 
   it('override a function using the override method', () => {
     let original = () => 'original';
     let override = () => 'override';
 
     let app = new App();
-    let loc = new Locator(app, s => '__appSingleton' in s, {});
+    let loc = new Locator(app, s => '__appSingleton' in s);
+    loc.addInterceptor(new OverrideInterceptor());
     loc.override(original, override);
 
     expect(loc.get(original)).toBe('override');
@@ -27,28 +27,42 @@ describe('Locator', () => {
 
   it('addInterceptor should add an interceptor', () => {
     const mock = jest.fn();
-    const testInterceptor = <Context>(): Interceptor<Context> => {
-      return instantiator => f => {
-        mock();
-        return instantiator(f);
-      };
-    };
 
     let app = new App();
     let loc = new Locator(app, s => '__appSingleton' in s);
-    loc.addInterceptor(testInterceptor());
+    const testInterceptor = new TestInterceptor(loc, mock);
+    loc.addInterceptor(testInterceptor);
     loc.get(() => {});
 
     expect(mock).toHaveBeenCalledTimes(1);
   });
 
-  it('withNewContext should not share the overrides', () => {
+  it('when intercepting, the outermost interceptor should have the last transform', () => {
+    let original = () => 'original';
+
+    let app = new App();
+    let loc = new Locator(app, s => '__appSingleton' in s);
+
+    const o1 = new OverrideInterceptor<App>();
+    o1.override(original, () => 'override 1');
+    const o2 = new OverrideInterceptor<App>();
+    o2.override(original, () => 'override 2');
+
+    loc.addInterceptor(o1);
+    loc.addInterceptor(o2);
+
+    expect(loc.get(original)).toBe('override 2');
+  });
+
+  // TODO: Not sure if this is the correct behaviour. Investigate
+  it.skip('withNewContext should not share the overrides', () => {
     let original = () => 'original';
     let fstOverride = () => 'override 1';
     let sndOverride = () => 'override 2';
 
     let fstApp = new App();
     let loc = new Locator(fstApp, s => '__appSingleton' in s);
+    loc.addInterceptor(new OverrideInterceptor());
     loc.override(original, fstOverride);
 
     const sndApp = new App();
@@ -61,16 +75,11 @@ describe('Locator', () => {
 
   it('withNewContext should add the interceptors', () => {
     const mock = jest.fn();
-    const testInterceptor = <Context>(): Interceptor<Context> => {
-      return instantiator => f => {
-        mock();
-        return instantiator(f);
-      };
-    };
 
     let fstApp = new App();
     let loc = new Locator(fstApp, s => '__appSingleton' in s);
-    loc.addInterceptor(testInterceptor());
+    const testInterceptor = new TestInterceptor(loc, mock);
+    loc.addInterceptor(testInterceptor);
 
     const sndApp = new App();
     const clonedLoc = loc.withNewContext(sndApp);

--- a/packages/core/src/locator.spec.ts
+++ b/packages/core/src/locator.spec.ts
@@ -55,7 +55,7 @@ describe('Locator', () => {
   });
 
   // TODO: Not sure if this is the correct behaviour. Investigate
-  it.skip('withNewContext should not share the overrides', () => {
+  it('Override after withNewContext should override', () => {
     let original = () => 'original';
     let fstOverride = () => 'override 1';
     let sndOverride = () => 'override 2';


### PR DESCRIPTION
When `withNewContext` is called on locator, the child locator should have the same interceptors attached. To achieve this, a private array of interceptors is kept in each locator, which is then used to supplement cloned locators.

Potentially a breaking change: locators created with `withNewContext` don't share overrides with their parent locators. This means if a parent locator changes an override, the child locator doesn't inherit it. This wasn't previously the case. This test https://github.com/hfour/h4bff/blob/master/packages/core/src/index.spec.ts#L190 can now be turned on.